### PR TITLE
stm32f7: Fix compile error caused by intentional use of fall through

### DIFF
--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -1919,6 +1919,7 @@ static void stm32_clock(FAR struct sdio_dev_s *dev, enum sdio_clock_e rate)
             clckr = (STM32_SDMMC_CLCKR_SDWIDEXFR | STM32_SDMMC_CLKCR_CLKEN);
             break;
           }
+	/* FALLTHROUGH */
 
       /* SD normal operation clocking (narrow 1-bit mode) */
 


### PR DESCRIPTION
Fixes a compile error generated when building for stm32f7 target using latest PX4 build environment.